### PR TITLE
Potential fix for code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/repository/user_repo_impl.go
+++ b/repository/user_repo_impl.go
@@ -31,7 +31,7 @@ func (repo UserRepoImpl) CreateUser(ctx context.Context, tx *sql.Tx, user entity
 	uuid := utils.GenerateUUID()
 
 	SQL := "insert into management.users (uuid, email, password) values ($1, $2, $3)"
-	fmt.Println(SQL, uuid, user.Email, user.Password)
+	fmt.Println(SQL, uuid, user.Email, "[REDACTED]")
 	_, err := tx.ExecContext(ctx, SQL, uuid, user.Email, user.Password)
 	if err != nil {
 		helper.PanicIfError(err)


### PR DESCRIPTION
Potential fix for [https://github.com/PakaiWA/api/security/code-scanning/1](https://github.com/PakaiWA/api/security/code-scanning/1)

To fix the issue, we should remove the logging of sensitive information such as `user.Password`. Instead, we can log other non-sensitive details (e.g., `user.Email` or `uuid`) to provide sufficient context for debugging without exposing sensitive data. The password should not be logged in any form, even if encrypted or hashed, as it is unnecessary for debugging purposes.

The fix involves modifying the logging statement on line 34 to exclude `user.Password`. Additionally, we should review other logging statements in the function to ensure no sensitive information is inadvertently logged.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
