### PR TITLE
Potential fix for code scanning alert no. 2: Clear-text logging of sensitive information

### DIFF
--- a/repository/user_repo_impl.go
+++ b/repository/user_repo_impl.go
@@ -39,8 +39,8 @@ func (repo UserRepoImpl) CreateUser(ctx context.Context, tx *sql.Tx, user entity
 
 	helper.PanicIfError(err)
 	user.Uuid = uuid
-	user.Password = ""
-	fmt.Println("Success create user", user)
+	user.Password = "" // Clear sensitive data
+	fmt.Printf("Success create user with UUID: %s and Email: %s\n", user.Uuid, user.Email)
 	return user
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/PakaiWA/api/security/code-scanning/2](https://github.com/PakaiWA/api/security/code-scanning/2)

To fix the issue, we need to ensure that sensitive information, such as the `Password` field, is not logged in clear text. The best approach is to exclude the `Password` field entirely from the logging statement. This can be achieved by creating a sanitized version of the `user` object that omits sensitive fields before logging. Additionally, we should review all logging statements to ensure no sensitive data is inadvertently exposed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
